### PR TITLE
Fix CRTP base for HSL color class

### DIFF
--- a/lib/include/htracer/colors/hsl.hxx
+++ b/lib/include/htracer/colors/hsl.hxx
@@ -13,7 +13,7 @@ class srgb;
 
 
 template<typename Float>
-class hsl final : private utils::vector_crtp<srgb<Float>, Float, 3>
+class hsl final : private utils::vector_crtp<hsl<Float>, Float, 3>
 {
 public:
   constexpr hsl(Float h, Float s, Float l) noexcept;

--- a/lib/include/htracer/colors/hsl_impl.hxx
+++ b/lib/include/htracer/colors/hsl_impl.hxx
@@ -15,7 +15,7 @@ namespace htracer::colors
 
 template<typename Float>
 constexpr hsl<Float>::hsl(Float h, Float s, Float l) noexcept
-    : utils::vector_crtp<srgb<Float>, Float, 3>{h, s, l}
+    : utils::vector_crtp<hsl<Float>, Float, 3>{h, s, l}
 {
 }
 


### PR DESCRIPTION
## Summary
- fix base class template parameters for `hsl` color type so that it uses itself as CRTP derived type

## Testing
- `cmake -S . -B build -DHTRACER_BUILD_TESTS=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`